### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Future updates to this repository will include additional examples of how to per
 ## Resources
 
 1. [AMD SEV-SNP ABI Specification (PDF)](https://www.amd.com/system/files/TechDocs/56860.pdf)
-2. [AMD Signing Key (ASK) and AMD Root Key (ARK) Certificates for Milan Processors](https://developer.amd.com/wp-content/resources/ask_ark_milan.cert)
+2. [AMD Signing Key (ASK) and AMD Root Key (ARK) Certificates for Milan Processors](https://download.amd.com/developer/eula/sev/ask_ark_milan.cert)
 


### PR DESCRIPTION
The developer portal was reorganized away from wordpress, and this is the new link to the SEV ABI certificate blob for Milan's ARK_ASK certificate bundle.